### PR TITLE
Felles pre-push mot main med linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ IntelliJ-oppsett.
 
 ### Developer
 
+- Set opp pre-push hooks for kotlin-backends
+  - Kjør `./dev/setupProject.sh` (må kjøres fra `./tilleggsstonader`)
 -   [Gradle](./doc/dev/gradle.md)
 
 ### Hente nye repoen som eg lagt til

--- a/dev/git-hooks-backend/pre-push
+++ b/dev/git-hooks-backend/pre-push
@@ -1,0 +1,18 @@
+#!/bin/sh
+#########################################################################################
+###
+### Når man pusher til main så kjøres lint-sjekk og feiler push hvis man mangler linting
+### Dette er for å unngå at man pusher kode som likevel kommer feile bygget.
+###
+#########################################################################################
+
+# Det er mulig å pushe flere brancher samtidig, så sjekken gjøres per branch
+while read local_ref local_sha remote_ref remote_sha
+do
+  #Extract the branch name from the remote reference
+  branch_name=$(git rev-parse --symbolic --abbrev-ref "$remote_ref")
+
+  if [ "$branch_name" = "main" ]; then
+      ./gradlew spotlessCheck
+  fi
+done

--- a/dev/setupProject.sh
+++ b/dev/setupProject.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Lager symlinks til pre-push script for backends(kotlin) som kjører lint og feiler vid feil
+# -n: If the target file already exists, do not overwrite it.
+#   This prevents accidentally overwriting an existing pre-commit hook with a new one.
+# -i: interative, spør om sletting av eksisterende
+# -s: symbolic link
+ln -nsi "../../../dev/git-hooks-backend/pre-push" "tilleggsstonader-arena/.git/hooks/pre-push"
+ln -nsi "../../../dev/git-hooks-backend/pre-push" "tilleggsstonader-integrasjoner/.git/hooks/pre-push"
+ln -nsi "../../../dev/git-hooks-backend/pre-push" "tilleggsstonader-kontrakter/.git/hooks/pre-push"
+ln -nsi "../../../dev/git-hooks-backend/pre-push" "tilleggsstonader-libs/.git/hooks/pre-push"
+ln -nsi "../../../dev/git-hooks-backend/pre-push" "tilleggsstonader-sak/.git/hooks/pre-push"
+ln -nsi "../../../dev/git-hooks-backend/pre-push" "tilleggsstonader-soknad-api/.git/hooks/pre-push"
+echo "Opprettet symlinks"


### PR DESCRIPTION
Laget en pre-push hook som kjører lint når man prøver å pushe til main.
Tanken var først en pre-commit, men det finnes mulighet å lage en branch, commite, og sen mergea denne og pushe til main. Då er det bedre å sjekke lint ved push tenker jeg :-) 

Oppretter symlinks i alle backend-repos som kjører `spotlessCheck`.
Dvs for tilleggsstonader-sak legges det inn en
`.git/hooks/pre-push -> ../../../dev/git-hooks-backend/pre-push` som då peker til dette repositories sin pre-push som ligger i `dev/git-hooks-backend` 